### PR TITLE
Add Prometheus Metrics to Subgraph Queries

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,8 @@
     "express": "^4.17.3",
     "express-graphql": "^0.12.0",
     "graphql": "^16.3.0",
-    "graphql-request": "^4.1.0"
+    "graphql-request": "^4.1.0",
+    "prom-client": "^14.2.0"
   },
   "devDependencies": {
     "@types/chai": "^4.3.0",

--- a/server/src/metrics.ts
+++ b/server/src/metrics.ts
@@ -1,0 +1,17 @@
+import express, { Router } from "express";
+import { Counter, register } from "prom-client";
+
+export const subgraphQueries = new Counter({
+  name: "subgraph_queries",
+  help: "Counter for requests by result to the token subgraph.",
+  labelNames: ["result"],
+});
+
+export function serveMetrics(port: number) {
+  express()
+    .use(Router().get("/metrics", async (_, res) => {
+      res.setHeader("content-type", "text/plain");
+      return res.send(await register.metrics());
+    }))
+    .listen(port);
+}

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { GraphQLClient, gql } from "graphql-request";
 
+import * as metrics from "./metrics";
 import { formatTokenUnit } from "./util";
 
 const DEFAULT_SUBGRAPH_URL =
@@ -38,9 +39,13 @@ export async function handleSupplyQuery(
   const client = new GraphQLClient(SUBGRAPH_URL ?? DEFAULT_SUBGRAPH_URL);
   try {
     const { supply } = await client.request(query);
+
+    metrics.subgraphQueries.labels({ result: "ok" }).inc();
     return supply;
   } catch (err) {
     console.error(err);
+
+    metrics.subgraphQueries.labels({ result: "err" }).inc();
     return null;
   }
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,4 +1,6 @@
 import app from "./app";
+import { serveMetrics } from "./metrics";
+
 const port = 8080; // default port to listen
 
 // start the Express server
@@ -6,3 +8,6 @@ app.listen(port, () => {
   // tslint:disable-next-line:no-console
   console.log(`server started at http://localhost:${port}`);
 });
+
+// Serve metrics on a separate port.
+serveMetrics(9989);

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -248,6 +248,11 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
+bintrees@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.2.tgz#49f896d6e858a4a499df85c38fb399b9aff840f8"
+  integrity sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==
+
 body-parser@1.19.2:
   version "1.19.2"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.2.tgz#4714ccd9c157d44797b8b5607d72c0b89952f26e"
@@ -1527,6 +1532,13 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+prom-client@^14.2.0:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.2.0.tgz#ca94504e64156f6506574c25fb1c34df7812cf11"
+  integrity sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==
+  dependencies:
+    tdigest "^0.1.1"
+
 proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -1790,6 +1802,13 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+tdigest@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.2.tgz#96c64bac4ff10746b910b0e23b515794e12faced"
+  integrity sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==
+  dependencies:
+    bintrees "1.0.2"
 
 to-readable-stream@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR adds prometheus metrics to the simple API. Since we will be trying out different subgraphs, this allows us to make sure that the new system we are using doesn't break anything.

### Test Plan

Do some queries and check the metrics (you can cause an error to happen by requesting for a non-existant block):
```
$ curl -s http://localhost:9989/metrics
# HELP subgraph_queries Counter for requests by result to the token subgraph.
# TYPE subgraph_queries counter
subgraph_queries{result="ok"} 2
subgraph_queries{result="err"} 1
```